### PR TITLE
Update resultsLink.js

### DIFF
--- a/server/src/controllers/resultsLink.js
+++ b/server/src/controllers/resultsLink.js
@@ -11,7 +11,7 @@ module.exports.newResult = function (params) {
   let timestamp = String(new Date().getTime())
   let allureInput = path.join(inputDir, timestamp)
   fse.ensureDirSync(allureInput)
-  let pathToSummaryJson = path.join(allureInput, 'widgets', 'summary.json')
+  let pathToSummaryJson = path.join(allureInput, 'summary.json')
 
   let integration = $store.getters.integrations[params.integration]
 


### PR DESCRIPTION
fix to avoid following error:  ENOENT: no such file or directory, open 'C:\\da-board\\server\\workDir\\input\\1664214748346\\widgets\\summary.json'